### PR TITLE
chore: vitestのセットアップ

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix .",
     "format": "npx prettier --write .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "vitest --run"
   },
   "lint-staged": {
     "*": "npm run format",
@@ -27,6 +28,7 @@
     "globals": "^15.1.0",
     "husky": "^9.0.11",
     "typescript-eslint": "^7.8.0",
+    "vitest": "^1.6.0",
     "wrangler": "^3.47.0"
   }
 }

--- a/src/api/figures/getFigureDetail.test.ts
+++ b/src/api/figures/getFigureDetail.test.ts
@@ -1,0 +1,186 @@
+import app from './getFigureDetail';
+import { getPlatformProxy, unstable_dev, type UnstableDevWorker } from 'wrangler';
+
+const { env } = await getPlatformProxy();
+
+describe('GET /api/figures/:id', () => {
+  let worker: UnstableDevWorker;
+
+  beforeAll(async () => {
+    worker = await unstable_dev('./src/index.ts', {
+      experimental: {
+        disableExperimentalWarning: true,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await worker.stop();
+  });
+
+  describe('存在するIDである', async () => {
+    const res = await app.request('/1', {}, env);
+
+    it('存在するIDのため200となり取得可能', async () => {
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        figure: {
+          id: 1,
+          lastName: '夏侯',
+          firstName: '惇',
+          courtesyName: '元譲',
+          lastNameKana: 'カコウ',
+          firstNameKana: 'トン',
+          courtesyNameKana: 'ゲンジョウ',
+          bornEra: null,
+          bornYear: null,
+          isBornContain: false,
+          diedEra: 'AD',
+          diedYear: 221,
+          isDiedContain: true,
+          country: '中国',
+          portrait: 'XiahouDun.jpg',
+          episode:
+            '曹操の重臣。前漢の夏侯嬰［カコウエイ］の末裔。\n' +
+            '【演義】曹操の挙兵以来、常に従軍。董卓追撃戦では、徐栄に敗れた曹操を救出し、徐栄を突き殺す。呂布との戦いでは、曹性の矢を左目に受けながらも曹性を討った。劉備が諸葛亮を登用すると新野に侵攻するが、諸葛亮の火攻めに遭って大敗。許都で耿紀と韋晃が曹操に反乱を起こした時は鎮圧に当たった。劉備軍との漢中攻防戦で、曹操が漏らした「鶏肋」という言葉の意を楊脩に尋ね、撤退を指揮。曹操が死ぬと後を追うように病死した。\n' +
+            '【正史】左目を失い盲夏侯と呼ばれる。曹丕の代に大将軍。',
+          abilities: [
+            {
+              seriesName: '三國志',
+              leadership: null,
+              power: 82,
+              intellect: 64,
+              political: null,
+              charisma: 79,
+            },
+            {
+              seriesName: '三國志2',
+              leadership: null,
+              power: 93,
+              intellect: 59,
+              political: null,
+              charisma: 71,
+            },
+            {
+              seriesName: '三國志3',
+              leadership: null,
+              power: 95,
+              intellect: 60,
+              political: 54,
+              charisma: 75,
+            },
+            {
+              seriesName: '三國志4',
+              leadership: 94,
+              power: 96,
+              intellect: 62,
+              political: 56,
+              charisma: 78,
+            },
+            {
+              seriesName: '三國志5',
+              leadership: null,
+              power: 94,
+              intellect: 70,
+              political: 81,
+              charisma: 87,
+            },
+            {
+              seriesName: '三國志6',
+              leadership: 88,
+              power: 92,
+              intellect: 71,
+              political: 84,
+              charisma: 82,
+            },
+            {
+              seriesName: '三國志7',
+              leadership: null,
+              power: 91,
+              intellect: 72,
+              political: 74,
+              charisma: 83,
+            },
+            {
+              seriesName: '三國志8',
+              leadership: null,
+              power: 92,
+              intellect: 63,
+              political: 68,
+              charisma: 84,
+            },
+            {
+              seriesName: '三國志9',
+              leadership: 90,
+              power: 92,
+              intellect: 64,
+              political: 76,
+              charisma: null,
+            },
+            {
+              seriesName: '三國志10',
+              leadership: 87,
+              power: 89,
+              intellect: 61,
+              political: 76,
+              charisma: 87,
+            },
+            {
+              seriesName: '三國志11',
+              leadership: 89,
+              power: 90,
+              intellect: 58,
+              political: 70,
+              charisma: 81,
+            },
+            {
+              seriesName: '三國志12',
+              leadership: 92,
+              power: 90,
+              intellect: 63,
+              political: 70,
+              charisma: null,
+            },
+            {
+              seriesName: '三國志13',
+              leadership: 89,
+              power: 91,
+              intellect: 62,
+              political: 72,
+              charisma: null,
+            },
+            {
+              seriesName: '三國志14',
+              leadership: 89,
+              power: 90,
+              intellect: 60,
+              political: 74,
+              charisma: 88,
+            },
+          ],
+          medianAbility: {
+            leadership: 89,
+            power: 92,
+            intellect: 63,
+            political: 73,
+            charisma: 82,
+          },
+          militaries: [
+            { name: '曹操軍（魏）', joinedOrder: 1 },
+            { name: '魏', joinedOrder: 2 },
+          ],
+          weapons: [],
+        },
+      });
+    });
+  });
+
+  describe('存在しないIDである', async () => {
+    const res = await app.request('/0', {}, env);
+
+    it('存在しないIDのため404となり取得不可能', async () => {
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ message: 'Figure not found.' });
+    });
+  });
+});

--- a/src/api/figures/getFiguresList.test.ts
+++ b/src/api/figures/getFiguresList.test.ts
@@ -1,0 +1,60 @@
+import app from './getFiguresList';
+import { getPlatformProxy, unstable_dev, type UnstableDevWorker } from 'wrangler';
+
+const { env } = await getPlatformProxy();
+
+describe('GET /api/figures', async () => {
+  let worker: UnstableDevWorker;
+
+  beforeAll(async () => {
+    worker = await unstable_dev('./src/index.ts', {
+      experimental: {
+        disableExperimentalWarning: true,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await worker.stop();
+  });
+
+  it('レスポンスの取得が可能', async () => {
+    const res = await app.request('/', {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      figures: [
+        {
+          id: 1,
+          lastName: '夏侯',
+          firstName: '惇',
+          courtesyName: '元譲',
+          lastNameKana: 'カコウ',
+          firstNameKana: 'トン',
+          courtesyNameKana: 'ゲンジョウ',
+          portrait: 'XiahouDun.jpg',
+        },
+        {
+          id: 2,
+          lastName: '周',
+          firstName: '瑜',
+          courtesyName: '公瑾',
+          lastNameKana: 'シュウ',
+          firstNameKana: 'ユ',
+          courtesyNameKana: 'コウキン',
+          portrait: 'ZhouYu.jpg',
+        },
+        {
+          id: 3,
+          lastName: '趙',
+          firstName: '雲',
+          courtesyName: '子龍',
+          lastNameKana: 'チョウ',
+          firstNameKana: 'ウン',
+          courtesyNameKana: 'シリュウ',
+          portrait: 'ZhaoYun.jpg',
+        },
+      ],
+    });
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,9 @@
+import app from '.';
+
+describe('GET /', () => {
+  it('テキストの取得が可能', async () => {
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toEqual('Hello Hono!');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "lib": ["ESNext"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "vitest/globals"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['**/src/**/(*.)+(spec|test).+(ts|tsx|js)'],
+  },
+});


### PR DESCRIPTION
- APIのテストも追加
- pre-pushでテスト実行する設定を追加
```
 ✓ src/index.test.ts (1)
 ✓ src/api/figures/getFiguresList.test.ts (1) 672ms
 ✓ src/api/figures/getFigureDetail.test.ts (2) 598ms

 Test Files  3 passed (3)
      Tests  4 passed (4)
   Start at  02:02:59
   Duration  5.25s (transform 2.99s, setup 0ms, collect 8.74s, tests 1.30s, environment 1ms, prepare 311ms)
```